### PR TITLE
Add Disney wait time monitoring service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+
+EXPOSE 8000
+CMD ["uvicorn", "disneywaits.service:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/README.md
+++ b/README.md
@@ -28,3 +28,11 @@ docker run -p 8000:8000 disneywaits
 ```
 
 The service polls the API every five minutes while running.
+
+### Debugging
+
+Set the log level to `debug` to troubleshoot data collection. For example:
+
+```bash
+uvicorn disneywaits.service:app --log-level debug
+```

--- a/README.md
+++ b/README.md
@@ -1,1 +1,27 @@
 # DisneyWaits
+
+Service that polls the [queue-times](https://queue-times.com) API for
+attraction wait times at Disney parks.  It keeps a five day running
+average and standard deviation for each ride and flags rides with a
+current wait more than one standard deviation below their average.
+
+## Running locally
+
+```bash
+python -m pip install -r requirements.txt
+uvicorn disneywaits.service:app --reload
+```
+
+The service exposes:
+
+- `GET /parks` – list of known parks
+- `GET /parks/{park_id}/wait_times` – current wait times and statistics
+
+## Docker
+
+```bash
+docker build -t disneywaits .
+docker run -p 8000:8000 disneywaits
+```
+
+The service polls the API every five minutes while running.

--- a/README.md
+++ b/README.md
@@ -17,9 +17,8 @@ uvicorn disneywaits.service:app --reload
 The service exposes:
 
 - `GET /parks` – list of known parks
-- `GET /wait_times?park_id={id}` – current wait times and statistics for all
-  rides, optionally filtered to a single park
-- `GET /parks/{park_id}/wait_times` – legacy endpoint equivalent to the above
+- `GET /wait_times?park_id={id}` or `/parks/wait_times` – current wait times
+  and statistics for all rides, optionally filtered to a single park
 
 ## Docker
 

--- a/README.md
+++ b/README.md
@@ -17,11 +17,14 @@ uvicorn disneywaits.service:app --reload
 The service exposes:
 
 - `GET /parks` – list of known parks
-- `GET /wait_times?park_id={id}` or `/parks/wait_times` – current wait times
-  and statistics for all rides, optionally filtered to a single park. Each
-  ride entry includes an `is_open` flag indicating whether the ride is
-  currently operating and a `recently_opened` flag that is `true` only on the
-  first poll after a ride reopens.
+- `GET /wait_times` or `/parks/wait_times` – current wait times and
+  statistics for all rides. Query parameters allow filtering:
+  - `park_id` – restrict to a single park
+  - `is_open` – only rides matching the open/closed state
+  - `is_unusually_low` – only rides whose wait is >1 stdev below average
+  
+  Each ride entry includes `is_open`, `recently_opened`, and
+  `is_unusually_low` flags.
 
 ## Docker
 

--- a/README.md
+++ b/README.md
@@ -36,3 +36,5 @@ Set the log level to `debug` to troubleshoot data collection. For example:
 ```bash
 uvicorn disneywaits.service:app --log-level debug
 ```
+This will log the flattened ride names for each park as they are fetched from
+queue-times, helping diagnose cases where no rides are returned.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,9 @@ The service exposes:
 
 - `GET /parks` – list of known parks
 - `GET /wait_times?park_id={id}` or `/parks/wait_times` – current wait times
-  and statistics for all rides, optionally filtered to a single park
+  and statistics for all rides, optionally filtered to a single park. Each
+  ride entry includes an `is_open` flag indicating whether the ride is
+  currently operating.
 
 ## Docker
 

--- a/README.md
+++ b/README.md
@@ -41,3 +41,5 @@ uvicorn disneywaits.service:app --log-level debug
 ```
 This will log the flattened ride names for each park as they are fetched from
 queue-times, helping diagnose cases where no rides are returned.
+
+Powered by [Queue-Times.com](https://queue-times.com/en-US)

--- a/README.md
+++ b/README.md
@@ -17,7 +17,9 @@ uvicorn disneywaits.service:app --reload
 The service exposes:
 
 - `GET /parks` – list of known parks
-- `GET /parks/{park_id}/wait_times` – current wait times and statistics
+- `GET /wait_times?park_id={id}` – current wait times and statistics for all
+  rides, optionally filtered to a single park
+- `GET /parks/{park_id}/wait_times` – legacy endpoint equivalent to the above
 
 ## Docker
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,11 @@
 # DisneyWaits
 
 Service that polls the [queue-times](https://queue-times.com) API for
-attraction wait times at Disney parks.  It keeps a five day running
-average and standard deviation for each ride and flags rides with a
-current wait more than one standard deviation below their average.
+attraction wait times at Disney parks. Only parks listed under "Walt Disney
+Attractions" are tracked and ride data is flattened across park areas.  It
+keeps a five day running average and standard deviation for each ride and
+flags rides with a current wait more than one standard deviation below their
+average.
 
 ## Running locally
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ The service exposes:
 - `GET /wait_times?park_id={id}` or `/parks/wait_times` – current wait times
   and statistics for all rides, optionally filtered to a single park. Each
   ride entry includes an `is_open` flag indicating whether the ride is
-  currently operating.
+  currently operating and a `recently_opened` flag that is `true` only on the
+  first poll after a ride reopens.
 
 ## Docker
 

--- a/disneywaits/__init__.py
+++ b/disneywaits/__init__.py
@@ -1,0 +1,1 @@
+"""DisneyWaits service package."""

--- a/disneywaits/queue_times.py
+++ b/disneywaits/queue_times.py
@@ -17,6 +17,8 @@ class QueueTimesClient:
         resp = await self.client.get(PARKS_URL)
         resp.raise_for_status()
         data = resp.json()
+        if isinstance(data, list):
+            return data
         return data.get("parks", data)
 
     async def fetch_wait_times(self, park_id: int | str) -> Dict[str, Any]:

--- a/disneywaits/queue_times.py
+++ b/disneywaits/queue_times.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import httpx
+from typing import Any, Dict, List
+
+PARKS_URL = "https://queue-times.com/parks.json"
+PARK_QUEUE_URL = "https://queue-times.com/parks/{park_id}/queue_times.json"
+
+
+class QueueTimesClient:
+    """HTTP client for the queue-times API."""
+
+    def __init__(self) -> None:
+        self.client = httpx.AsyncClient(headers={"User-Agent": "DisneyWaits/1.0"})
+
+    async def fetch_parks(self) -> List[Dict[str, Any]]:
+        resp = await self.client.get(PARKS_URL)
+        resp.raise_for_status()
+        data = resp.json()
+        return data.get("parks", data)
+
+    async def fetch_wait_times(self, park_id: int | str) -> Dict[str, Any]:
+        url = PARK_QUEUE_URL.format(park_id=park_id)
+        resp = await self.client.get(url)
+        resp.raise_for_status()
+        return resp.json()
+
+    async def close(self) -> None:
+        await self.client.aclose()
+

--- a/disneywaits/service.py
+++ b/disneywaits/service.py
@@ -83,22 +83,23 @@ class DisneyWaitsService:
         results = []
         for ride in rides:
             stats = ride.stats
-            if is_open is not None and stats.is_open != is_open:
+            entry = {
+                "id": ride.id,
+                "name": ride.name,
+                "current_wait": stats.current_wait,
+                "mean": stats.mean(),
+                "stdev": stats.stdev(),
+                "is_open": stats.is_open,
+                "recently_opened": stats.recently_opened,
+                "is_unusually_low": stats.is_unusually_low(),
+            }
+
+            if is_open is not None and entry["is_open"] != is_open:
                 continue
-            if is_unusually_low is not None and stats.is_unusually_low() != is_unusually_low:
+            if is_unusually_low is not None and entry["is_unusually_low"] != is_unusually_low:
                 continue
-            results.append(
-                {
-                    "id": ride.id,
-                    "name": ride.name,
-                    "current_wait": stats.current_wait,
-                    "mean": stats.mean(),
-                    "stdev": stats.stdev(),
-                    "is_open": stats.is_open,
-                    "recently_opened": stats.recently_opened,
-                    "is_unusually_low": stats.is_unusually_low(),
-                }
-            )
+
+            results.append(entry)
         return results
 
 client = QueueTimesClient()

--- a/disneywaits/service.py
+++ b/disneywaits/service.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from typing import Dict, List
+
+from fastapi import FastAPI
+
+from .queue_times import QueueTimesClient
+from .stats import RideStats
+
+
+@dataclass
+class RideInfo:
+    id: int | str
+    name: str
+    stats: RideStats = field(default_factory=RideStats)
+
+
+@dataclass
+class ParkInfo:
+    id: int | str
+    name: str
+    rides: Dict[int | str, RideInfo] = field(default_factory=dict)
+
+
+class DisneyWaitsService:
+    def __init__(self, client: QueueTimesClient) -> None:
+        self.client = client
+        self.parks: Dict[int | str, ParkInfo] = {}
+
+    async def update(self) -> None:
+        parks_data = await self.client.fetch_parks()
+        for park in parks_data:
+            park_id = park.get("id") or park.get("slug")
+            park_name = park.get("name")
+            park_info = self.parks.setdefault(park_id, ParkInfo(id=park_id, name=park_name))
+            await self._update_park(park_info)
+
+    async def _update_park(self, park: ParkInfo) -> None:
+        data = await self.client.fetch_wait_times(park.id)
+        lands = data.get("lands", [])
+        timestamp = datetime.now(UTC)
+        for land in lands:
+            for ride in land.get("rides", []):
+                ride_id = ride.get("id")
+                name = ride.get("name")
+                wait = ride.get("wait_time")
+                is_open = ride.get("is_open", True) and ride.get("status", "") not in {"Closed", "Refurbishment"}
+                ride_info = park.rides.setdefault(ride_id, RideInfo(id=ride_id, name=name))
+                if is_open and wait is not None:
+                    ride_info.stats.mark_open()
+                    ride_info.stats.add_wait(wait, timestamp)
+                else:
+                    ride_info.stats.mark_closed()
+
+    def park_wait_times(self, park_id: int | str) -> List[dict]:
+        park = self.parks.get(park_id)
+        if not park:
+            return []
+        results = []
+        for ride in park.rides.values():
+            stats = ride.stats
+            results.append(
+                {
+                    "id": ride.id,
+                    "name": ride.name,
+                    "current_wait": stats.current_wait,
+                    "mean": stats.mean(),
+                    "stdev": stats.stdev(),
+                    "is_unusually_low": stats.is_unusually_low(),
+                }
+            )
+        return results
+
+
+client = QueueTimesClient()
+service = DisneyWaitsService(client)
+app = FastAPI()
+
+
+@app.on_event("startup")
+async def startup() -> None:
+    async def poller() -> None:
+        while True:
+            try:
+                await service.update()
+            except Exception:  # pragma: no cover - logging omitted for brevity
+                pass
+            await asyncio.sleep(300)
+
+    asyncio.create_task(poller())
+
+
+@app.on_event("shutdown")
+async def shutdown() -> None:
+    await client.close()
+
+
+@app.get("/parks")
+async def parks() -> Dict[str, str]:
+    return {str(p.id): p.name for p in service.parks.values()}
+
+
+@app.get("/parks/{park_id}/wait_times")
+async def wait_times(park_id: str) -> List[dict]:
+    return service.park_wait_times(park_id)
+

--- a/disneywaits/service.py
+++ b/disneywaits/service.py
@@ -85,6 +85,7 @@ class DisneyWaitsService:
                     "mean": stats.mean(),
                     "stdev": stats.stdev(),
                     "is_open": stats.is_open,
+                    "recently_opened": stats.recently_opened,
                     "is_unusually_low": stats.is_unusually_low(),
                 }
             )

--- a/disneywaits/service.py
+++ b/disneywaits/service.py
@@ -40,21 +40,19 @@ class DisneyWaitsService:
             await self._update_park(park_info)
 
     async def _update_park(self, park: ParkInfo) -> None:
-        data = await self.client.fetch_wait_times(park.id)
-        lands = data.get("lands", [])
+        rides = await self.client.fetch_wait_times(park.id)
         timestamp = datetime.now(UTC)
-        for land in lands:
-            for ride in land.get("rides", []):
-                ride_id = ride.get("id")
-                name = ride.get("name")
-                wait = ride.get("wait_time")
-                is_open = ride.get("is_open", True) and ride.get("status", "") not in {"Closed", "Refurbishment"}
-                ride_info = park.rides.setdefault(ride_id, RideInfo(id=ride_id, name=name))
-                if is_open and wait is not None:
-                    ride_info.stats.mark_open()
-                    ride_info.stats.add_wait(wait, timestamp)
-                else:
-                    ride_info.stats.mark_closed()
+        for ride in rides:
+            ride_id = ride.get("id")
+            name = ride.get("name")
+            wait = ride.get("wait_time")
+            is_open = ride.get("is_open", True) and ride.get("status", "") not in {"Closed", "Refurbishment"}
+            ride_info = park.rides.setdefault(ride_id, RideInfo(id=ride_id, name=name))
+            if is_open and wait is not None:
+                ride_info.stats.mark_open()
+                ride_info.stats.add_wait(wait, timestamp)
+            else:
+                ride_info.stats.mark_closed()
 
     def park_wait_times(self, park_id: int | str) -> List[dict]:
         park = self.parks.get(park_id)

--- a/disneywaits/service.py
+++ b/disneywaits/service.py
@@ -75,7 +75,7 @@ class DisneyWaitsService:
             for park in self.parks.values():
                 rides.extend(park.rides.values())
         else:
-            park = self.parks.get(park_id)
+            park = self.parks.get(str(park_id))
             if not park:
                 return []
             rides = list(park.rides.values())

--- a/disneywaits/service.py
+++ b/disneywaits/service.py
@@ -80,10 +80,6 @@ class DisneyWaitsService:
             )
         return results
 
-    def park_wait_times(self, park_id: int | str) -> List[dict]:
-        return self.wait_times(park_id)
-
-
 client = QueueTimesClient()
 service = DisneyWaitsService(client)
 app = FastAPI()
@@ -119,11 +115,7 @@ async def parks() -> Dict[str, str]:
 
 
 @app.get("/wait_times")
+@app.get("/parks/wait_times")
 async def wait_times_endpoint(park_id: str | None = None) -> List[dict]:
-    return service.wait_times(park_id)
-
-
-@app.get("/parks/{park_id}/wait_times")
-async def wait_times(park_id: str) -> List[dict]:
     return service.wait_times(park_id)
 

--- a/disneywaits/service.py
+++ b/disneywaits/service.py
@@ -84,6 +84,7 @@ class DisneyWaitsService:
                     "current_wait": stats.current_wait,
                     "mean": stats.mean(),
                     "stdev": stats.stdev(),
+                    "is_open": stats.is_open,
                     "is_unusually_low": stats.is_unusually_low(),
                 }
             )

--- a/disneywaits/stats.py
+++ b/disneywaits/stats.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import statistics
+from collections import deque
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from typing import Deque, List, Tuple
+
+
+@dataclass
+class WaitEntry:
+    timestamp: datetime
+    wait: int
+
+
+class RideStats:
+    """Track wait time statistics for a single ride."""
+
+    def __init__(self) -> None:
+        self.history: Deque[WaitEntry] = deque()
+        self.current_wait: int | None = None
+        self.is_open: bool = True
+
+    def add_wait(self, wait: int, timestamp: datetime | None = None) -> None:
+        """Add a wait time sample.
+
+        Only stores samples from the last five days.
+        """
+        timestamp = timestamp or datetime.now(UTC)
+        self.current_wait = wait
+        self.history.append(WaitEntry(timestamp, wait))
+        self._trim_history(timestamp)
+
+    def mark_closed(self) -> None:
+        self.is_open = False
+        self.current_wait = None
+
+    def mark_open(self) -> None:
+        self.is_open = True
+
+    def _trim_history(self, now: datetime) -> None:
+        cutoff = now - timedelta(days=5)
+        while self.history and self.history[0].timestamp < cutoff:
+            self.history.popleft()
+
+    def mean(self) -> float | None:
+        if not self.history:
+            return None
+        return statistics.mean(entry.wait for entry in self.history)
+
+    def stdev(self) -> float | None:
+        if len(self.history) < 2:
+            return None
+        return statistics.stdev(entry.wait for entry in self.history)
+
+    def is_unusually_low(self) -> bool:
+        """Return True if current wait is >1 std dev below mean."""
+        if self.current_wait is None:
+            return False
+        mean = self.mean()
+        stdev = self.stdev()
+        if mean is None or stdev is None or stdev == 0:
+            return False
+        return self.current_wait < mean - stdev
+

--- a/disneywaits/stats.py
+++ b/disneywaits/stats.py
@@ -20,6 +20,7 @@ class RideStats:
         self.history: Deque[WaitEntry] = deque()
         self.current_wait: int | None = None
         self.is_open: bool = True
+        self.recently_opened: bool = False
 
     def add_wait(self, wait: int, timestamp: datetime | None = None) -> None:
         """Add a wait time sample.
@@ -34,8 +35,10 @@ class RideStats:
     def mark_closed(self) -> None:
         self.is_open = False
         self.current_wait = None
+        self.recently_opened = False
 
     def mark_open(self) -> None:
+        self.recently_opened = not self.is_open
         self.is_open = True
 
     def _trim_history(self, now: datetime) -> None:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+fastapi
+uvicorn
+httpx
+pytest

--- a/tests/test_queue_times.py
+++ b/tests/test_queue_times.py
@@ -54,3 +54,18 @@ def test_fetch_wait_times_flattens(monkeypatch):
     }
     waits = asyncio.run(_fetch_waits(monkeypatch, payload))
     assert [r["id"] for r in waits] == [1, 2, 3]
+
+
+def test_fetch_wait_times_flattens_nested(monkeypatch):
+    payload = {
+        "lands": [
+            {
+                "areas": [
+                    {"rides": [{"id": 4}]},
+                    {"areas": [{"rides": [{"id": 5}]}]},
+                ]
+            }
+        ]
+    }
+    waits = asyncio.run(_fetch_waits(monkeypatch, payload))
+    assert [r["id"] for r in waits] == [4, 5]

--- a/tests/test_queue_times.py
+++ b/tests/test_queue_times.py
@@ -1,0 +1,31 @@
+import asyncio
+import os, sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from disneywaits.queue_times import QueueTimesClient
+
+class DummyResp:
+    def __init__(self, data):
+        self._data = data
+    def json(self):
+        return self._data
+    def raise_for_status(self):
+        pass
+
+async def _fetch(monkeypatch, payload):
+    client = QueueTimesClient()
+    async def fake_get(url):
+        return DummyResp(payload)
+    monkeypatch.setattr(client.client, "get", fake_get)
+    parks = await client.fetch_parks()
+    await client.close()
+    return parks
+
+def test_fetch_parks_list(monkeypatch):
+    parks = asyncio.run(_fetch(monkeypatch, [{"id": 1, "name": "Park"}]))
+    assert parks == [{"id": 1, "name": "Park"}]
+
+def test_fetch_parks_dict(monkeypatch):
+    parks = asyncio.run(_fetch(monkeypatch, {"parks": [{"id": 2, "name": "Park2"}]}))
+    assert parks == [{"id": 2, "name": "Park2"}]

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -38,7 +38,9 @@ def test_service_update_and_query():
     ride_a = next(r for r in waits_all if r["id"] == "10")
     ride_b = next(r for r in waits_all if r["id"] == "11")
     assert ride_a["current_wait"] == 5
+    assert ride_a["is_open"] is True
     assert ride_b["current_wait"] is None
+    assert ride_b["is_open"] is False
     assert service.wait_times("missing") == []
 
 
@@ -62,6 +64,7 @@ def test_wait_times_endpoint():
             "current_wait": 5,
             "mean": 5,
             "stdev": None,
+            "is_open": True,
             "is_unusually_low": False,
         }
     ]

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -3,7 +3,16 @@ import pytest
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
-from disneywaits.service import DisneyWaitsService
+from disneywaits.service import (
+    DisneyWaitsService,
+    ParkInfo,
+    RideInfo,
+    app,
+    service as global_service,
+)
+from disneywaits.stats import RideStats
+from fastapi.testclient import TestClient
+from datetime import UTC, datetime
 
 
 class DummyClient:
@@ -22,9 +31,39 @@ def test_service_update_and_query():
     import asyncio
 
     asyncio.run(service.update())
-    waits = service.park_wait_times(1)
-    assert len(waits) == 2
-    ride_a = next(r for r in waits if r["id"] == 10)
-    ride_b = next(r for r in waits if r["id"] == 11)
+    waits_all = service.wait_times()
+    assert len(waits_all) == 2
+    waits_filtered = service.wait_times("1")
+    assert waits_filtered == waits_all
+    ride_a = next(r for r in waits_all if r["id"] == "10")
+    ride_b = next(r for r in waits_all if r["id"] == "11")
     assert ride_a["current_wait"] == 5
     assert ride_b["current_wait"] is None
+    assert service.wait_times("missing") == []
+
+
+def test_wait_times_endpoint():
+    global_service.parks = {
+        "1": ParkInfo(
+            id="1",
+            name="Test",
+            rides={"10": RideInfo(id="10", name="Ride", stats=RideStats())},
+        )
+    }
+    global_service.parks["1"].rides["10"].stats.add_wait(5, datetime.now(UTC))
+    client = TestClient(app)
+    resp = client.get("/wait_times")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data == [
+        {
+            "id": "10",
+            "name": "Ride",
+            "current_wait": 5,
+            "mean": 5,
+            "stdev": None,
+            "is_unusually_low": False,
+        }
+    ]
+    assert client.get("/wait_times", params={"park_id": "1"}).json() == data
+    assert client.get("/wait_times", params={"park_id": "2"}).json() == []

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -67,6 +67,15 @@ def test_wait_times_filters():
     assert [w["id"] for w in waits_not_low] == ["11"]
 
 
+def test_wait_times_accepts_int_park_id():
+    service = DisneyWaitsService(DummyClient())
+    import asyncio
+
+    asyncio.run(service.update())
+    assert service.wait_times(1) == service.wait_times("1")
+    assert service.wait_times(1, is_open=True)[0]["id"] == "10"
+
+
 class FlippingClient:
     def __init__(self) -> None:
         self.calls = 0

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -11,16 +11,10 @@ class DummyClient:
         return [{"id": 1, "name": "Test Park"}]
 
     async def fetch_wait_times(self, park_id):
-        return {
-            "lands": [
-                {
-                    "rides": [
-                        {"id": 10, "name": "Ride A", "wait_time": 5, "is_open": True},
-                        {"id": 11, "name": "Ride B", "wait_time": 0, "is_open": False},
-                    ]
-                }
-            ]
-        }
+        return [
+            {"id": 10, "name": "Ride A", "wait_time": 5, "is_open": True},
+            {"id": 11, "name": "Ride B", "wait_time": 0, "is_open": False},
+        ]
 
 
 def test_service_update_and_query():

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -1,0 +1,36 @@
+import os, sys
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from disneywaits.service import DisneyWaitsService
+
+
+class DummyClient:
+    async def fetch_parks(self):
+        return [{"id": 1, "name": "Test Park"}]
+
+    async def fetch_wait_times(self, park_id):
+        return {
+            "lands": [
+                {
+                    "rides": [
+                        {"id": 10, "name": "Ride A", "wait_time": 5, "is_open": True},
+                        {"id": 11, "name": "Ride B", "wait_time": 0, "is_open": False},
+                    ]
+                }
+            ]
+        }
+
+
+def test_service_update_and_query():
+    service = DisneyWaitsService(DummyClient())
+    import asyncio
+
+    asyncio.run(service.update())
+    waits = service.park_wait_times(1)
+    assert len(waits) == 2
+    ride_a = next(r for r in waits if r["id"] == 10)
+    ride_b = next(r for r in waits if r["id"] == 11)
+    assert ride_a["current_wait"] == 5
+    assert ride_b["current_wait"] is None

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -67,3 +67,6 @@ def test_wait_times_endpoint():
     ]
     assert client.get("/wait_times", params={"park_id": "1"}).json() == data
     assert client.get("/wait_times", params={"park_id": "2"}).json() == []
+    assert client.get("/parks/wait_times").json() == data
+    assert client.get("/parks/wait_times", params={"park_id": "1"}).json() == data
+

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -1,0 +1,25 @@
+from datetime import UTC, datetime, timedelta
+import os, sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from disneywaits.stats import RideStats
+
+
+def test_ride_stats_mean_std_and_unusual():
+    stats = RideStats()
+    now = datetime.now(UTC)
+    for i in range(5):
+        stats.add_wait(10 + i, now - timedelta(minutes=5 * i))
+    assert round(stats.mean(), 2) == 12.0
+    assert round(stats.stdev(), 2) > 0
+    stats.add_wait(1, now + timedelta(minutes=5))
+    assert stats.is_unusually_low()
+
+
+def test_ride_stats_trim_history():
+    stats = RideStats()
+    old = datetime.now(UTC) - timedelta(days=6)
+    stats.add_wait(10, old)
+    stats.add_wait(20)
+    assert len(stats.history) == 1

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -23,3 +23,12 @@ def test_ride_stats_trim_history():
     stats.add_wait(10, old)
     stats.add_wait(20)
     assert len(stats.history) == 1
+
+
+def test_recently_opened_flag():
+    stats = RideStats()
+    stats.mark_closed()
+    stats.mark_open()
+    assert stats.recently_opened is True
+    stats.mark_open()
+    assert stats.recently_opened is False


### PR DESCRIPTION
## Summary
- add FastAPI service to poll queue-times for Disney parks and track five-day wait time stats
- highlight rides with unusually low wait times and expose `/parks` and `/parks/{id}/wait_times` endpoints
- provide Dockerfile and docs for running the service

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ab4c5d761c832385d002383dcf0487