### PR TITLE
Add SSE ride alerts

### DIFF
--- a/disneywaits/index.html
+++ b/disneywaits/index.html
@@ -48,6 +48,10 @@
       background: #f2f2f2;
     }
 
+    .low {
+      font-weight: bold;
+    }
+
     footer {
       text-align: center;
       font-size: 0.9rem;
@@ -152,6 +156,9 @@
       openBody.innerHTML = '';
       for (const ride of openRides) {
         const row = document.createElement('tr');
+        if (ride.is_unusually_low) {
+          row.classList.add('low');
+        }
         const nameCell = document.createElement('td');
         nameCell.textContent = ride.name;
         const waitCell = document.createElement('td');

--- a/disneywaits/index.html
+++ b/disneywaits/index.html
@@ -87,6 +87,40 @@
   </div>
   <footer>Powered by <a href="https://queue-times.com/">Queue-Times.com</a></footer>
   <script>
+    let evtSource;
+
+    async function requestPermission() {
+      if ('Notification' in window && Notification.permission === 'default') {
+        try { await Notification.requestPermission(); } catch (e) {}
+      }
+    }
+
+    function connectEvents(rideIds) {
+      if (evtSource) {
+        evtSource.close();
+      }
+      if (!rideIds.length) {
+        return;
+      }
+      const params = new URLSearchParams({ ride_ids: rideIds.join(',') });
+      evtSource = new EventSource('/events?' + params.toString());
+      evtSource.onmessage = (event) => {
+        const data = JSON.parse(event.data);
+        const msg = data.event === 'opened'
+          ? `${data.ride_name} has opened`
+          : `${data.ride_name} wait is unusually low (${data.wait})`;
+        if ('Notification' in window && Notification.permission === 'granted') {
+          new Notification(msg);
+        } else {
+          console.log(msg);
+        }
+      };
+    }
+
+    window.addEventListener('beforeunload', () => {
+      if (evtSource) evtSource.close();
+    });
+
     async function loadParks() {
       const response = await fetch('/parks');
       const parks = await response.json();
@@ -140,12 +174,15 @@
         row.appendChild(statusCell);
         closedBody.appendChild(row);
       }
+
+      connectEvents(rides.map(r => r.id));
     }
 
     let refreshTimer;
     document.getElementById('park-select').addEventListener('change', (e) => {
       const parkId = e.target.value;
       loadRides(parkId);
+      requestPermission();
       if (refreshTimer) {
         clearInterval(refreshTimer);
       }

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ fastapi
 uvicorn
 httpx
 pytest
+sse-starlette

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -1,0 +1,53 @@
+import os, sys
+import asyncio
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from disneywaits.service import DisneyWaitsService
+
+class OpeningClient:
+    def __init__(self) -> None:
+        self.calls = 0
+
+    async def fetch_parks(self):
+        return [{"id": 1, "name": "Park"}]
+
+    async def fetch_wait_times(self, park_id):
+        self.calls += 1
+        if self.calls == 1:
+            return [{"id": 10, "name": "Ride", "wait_time": 0, "is_open": False}]
+        else:
+            return [{"id": 10, "name": "Ride", "wait_time": 5, "is_open": True}]
+
+class LowWaitClient:
+    def __init__(self) -> None:
+        self.calls = 0
+
+    async def fetch_parks(self):
+        return [{"id": 1, "name": "Park"}]
+
+    async def fetch_wait_times(self, park_id):
+        self.calls += 1
+        if self.calls < 4:
+            return [{"id": 10, "name": "Ride", "wait_time": 10, "is_open": True}]
+        else:
+            return [{"id": 10, "name": "Ride", "wait_time": 5, "is_open": True}]
+
+def test_service_notifies_on_open():
+    service = DisneyWaitsService(OpeningClient())
+    queue = service.subscribe({"10"})
+    asyncio.run(service.update())  # ride closed
+    asyncio.run(service.update())  # ride opens
+    event = asyncio.run(queue.get())
+    assert event["event"] == "opened"
+    assert event["ride_id"] == "10"
+
+def test_service_notifies_on_low_wait():
+    service = DisneyWaitsService(LowWaitClient())
+    queue = service.subscribe({"10"})
+    for _ in range(3):
+        asyncio.run(service.update())  # build history
+    asyncio.run(service.update())  # drop to low wait
+    event = asyncio.run(queue.get())
+    assert event["event"] == "unusually_low"
+    assert event["ride_id"] == "10"

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -20,3 +20,11 @@ def test_index_filters_zero_mean():
     path = Path(__file__).resolve().parent.parent / "disneywaits" / "index.html"
     text = path.read_text()
     assert "ride.mean !== 0" in text
+
+
+def test_index_marks_low_waits_bold():
+    path = Path(__file__).resolve().parent.parent / "disneywaits" / "index.html"
+    text = path.read_text()
+    assert ".low {" in text
+    assert "font-weight: bold" in text
+    assert "row.classList.add('low')" in text


### PR DESCRIPTION
## Summary
- stream ride updates via new `/events` SSE endpoint
- notify clients when rides open or wait times are unusually low
- connect browser page to SSE and show notifications for visible rides

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae4272ad2c8323986dd570405c1c5e